### PR TITLE
fix: handle resolve variadic function

### DIFF
--- a/core.go
+++ b/core.go
@@ -112,7 +112,12 @@ func (s *submodule[T]) SafeResolveWith(as Scope) (t T, e error) {
 			args[i] = v
 		}
 
-		result := reflect.ValueOf(s.input).Call(args)
+		var result []reflect.Value
+		if inputType.IsVariadic() {
+			result = reflect.ValueOf(s.input).CallSlice(args)
+		} else {
+			result = reflect.ValueOf(s.input).Call(args)
+		}
 		if len(result) == 1 {
 			v = scope.initValue(s, result[0])
 		} else {

--- a/submodule_test.go
+++ b/submodule_test.go
@@ -357,6 +357,20 @@ func TestModuleFunction(t *testing.T) {
 		require.Nil(t, e)
 		require.Equal(t, nums{1, 2}, rs)
 	})
+
+	t.Run("can resolve variadic function", func(t *testing.T) {
+		initMod := submodule.Value[int](0)
+		aMod := submodule.Value[[]int]([]int{1,2,3})
+		sumMod := submodule.Make[int](func (init int, a ...int) int {
+			sum := init
+			for _,v:=range a {
+				sum+=v
+			}
+			return sum
+		}, aMod, initMod)
+		sum := sumMod.Resolve()
+		require.Equal(t, sum, 6)
+	})
 }
 
 type Counter struct {


### PR DESCRIPTION
Currently, submodule is not support initialize function if it is variadic function.
Because it try to resolve the last argument with type slice, but reflect.Call will fail to execute, we need to use reflect.CallSlice( which is expand slice to individual value).
Support variadic initialize function is very valid use case, for examples:
Constructor(options ...Options), max(nums ...int).
Without variadic support, user need to workout around by create new function that call original initialize function which is quite tedious.